### PR TITLE
Update to Gnome 45

### DIFF
--- a/net.sapples.LiveCaptions.json
+++ b/net.sapples.LiveCaptions.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "net.sapples.LiveCaptions",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "43",
+    "runtime-version" : "45",
     "sdk" : "org.gnome.Sdk",
     "command" : "livecaptions",
     "finish-args" : [

--- a/net.sapples.LiveCaptions.json
+++ b/net.sapples.LiveCaptions.json
@@ -82,8 +82,8 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/abb128/LiveCaptions",
-                    "tag": "v0.4.0",
-                    "commit" : "773b035e3285a8894820100a9baf38ff5c3e47f8"
+                    "tag": "v0.4.1",
+                    "commit" : "df0540a20c7122b8d4e663c8a60008e82533846f"
                 }
             ]
         }


### PR DESCRIPTION
I got the message gnome 43 is end of life.

```
Info: runtime org.gnome.Platform branch 43 is end-of-life, with reason:
   The GNOME 43 runtime is no longer supported as of September 20, 2023. Please ask your application developer to migrate to a supported platform.
Info: applications using this runtime:
   net.sapples.LiveCaptions
```