### PR TITLE
chore: bump runtime to gnome 48

### DIFF
--- a/net.sapples.LiveCaptions.json
+++ b/net.sapples.LiveCaptions.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "net.sapples.LiveCaptions",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "command" : "livecaptions",
     "finish-args" : [


### PR DESCRIPTION
can be tested with `flatpak run --runtime-version=48 net.sapples.LiveCaptions`